### PR TITLE
Add Cryptography to Reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ PyYAML==3.12
 six==1.11.0
 subprocess32==3.2.7
 Werkzeug==0.13
+cryptography==3.3.2


### PR DESCRIPTION
The reqs were missing a package, see below

```
(.venv) ➜  src git:(training) ✗ python dpe.py

('xbar_ip_energy_dict', {'60': 170.00000000000003, '0': 170.00000000000003, '20': 170.00000000000003, '70': 170.00000000000003, '90': 170.00000000000003, '80': 170.00000000000003, '30': 170.00000000000003, '50': 170.00000000000003, '40': 170.00000000000003, '10': 170.00000000000003})
('xbar_ip_energy_dict', {'60': 170.00000000000003, '0': 170.00000000000003, '20': 170.00000000000003, '70': 170.00000000000003, '90': 170.00000000000003, '80': 170.00000000000003, '30': 170.00000000000003, '50': 170.00000000000003, '40': 170.00000000000003, '10': 170.00000000000003})
Traceback (most recent call last):
  File "dpe.py", line 62, in <module>
    from Factory import Factory
  File "/home/ubuntu22/git-repos/2puma/puma-simulator/Security/Factory.py", line 12, in <module>
    from PumaFernet import PumaFernet
  File "/home/ubuntu22/git-repos/2puma/puma-simulator/Security/PumaFernet.py", line 13, in <module>
    from cryptography.fernet import Fernet
ImportError: No module named cryptography.fernet
```